### PR TITLE
minor bugfixes & optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ sudo apt-get install libgflags-dev
 sudo apt-get install liblog4cxx-dev
 sudo apt-get install libomp-dev
 sudo apt-get install libeigen3-dev
-https://github.com/xptree/NetSMF.git
+git clone https://github.com/xptree/NetSMF.git
 cd NetSMF
 mkdir build
 ./configure
@@ -72,7 +72,7 @@ For unweighted networks, see `example/blog.sh` for an example.
 
 `blog.sh` takes three arguments, the first one indicates the input edgelist file, the second one indicates the output file, the third one indicating the origin `.mat` file containing network and labels.
 
-For exmaple, runing `./blog.sh blogcatalog.edgelist blogcatalog.netsmf blogcatalog.mat` will
+For exmaple, running `./blog.sh blogcatalog.edgelist blogcatalog.netsmf blogcatalog.mat` will
 
 * check if `blogcatalog.edgelist` is a valid file. If not, it calls `mat2edge.py` to translate mat file `blogcatalog.mat` to edgelist `blogcatalog.edgelist`.
 * call NetSMF algorithm, and store the 128-dim embedding at `blogcatalog.netsmf_128.npy`.

--- a/example/mat2edge.py
+++ b/example/mat2edge.py
@@ -14,19 +14,17 @@ def load_adjacency_matrix(file, variable_name="network"):
     return data[variable_name]
 
 def mat2edge(file, output):
-    print("mat2edgelist from %s to %s" % (file, output))
+    print(f"mat2edgelist from {file} to {output}")
     A = load_adjacency_matrix(file)
     A.eliminate_zeros()
     min_v, max_v = min(A.data) , max(A.data)
-    print("minimum non-zero value=%.2f maximum non-zero value=%.2f" \
-            % (min_v, max_v))
+    print(f"minimum non-zero value={min_v:.2f} maximum non-zero value={max_v:.2f}")
     unweighted = math.isclose(min_v, 1.0) and math.isclose(max_v, 1.0)
     print("unweighted graph" if unweighted else "weighted graph")
-    A = A.todok()
+    A = A.tocoo()
     with open(output, "w") as f:
-        for (x, y), v in A.items():
-            assert(math.isclose(A[y, x], v))
-            print("%d\t%d" % (x, y) if unweighted else "%d\t%d\t%f" % (x, y, v),end="\n", file=f)
+        for x, y, v in zip(A.row, A.col, A.data):
+            print(f"{x}\t{y}" if unweighted else f"{x}\t{y}\t{v}", file=f)
 
 if __name__ == "__main__":
     #mat2edge("youtube.mat", "youtube.edge")

--- a/src/redsvd/redsvd.hpp
+++ b/src/redsvd/redsvd.hpp
@@ -81,7 +81,7 @@ public:
 
     // Compute Sample Matrix of B
     Eigen::MatrixXf Z = B * P;
-    LOG4CXX_INFO(logger, "compute sample matrix of Z = B * P done.")
+    LOG4CXX_INFO(logger, "compute sample matrix of Z = B * P done.");
 
     // Orthonormalize Z
     Util::processGramSchmidt(Z);


### PR DESCRIPTION
Interesting paper :)

There were a few changes I needed to make to get this to work.
The most notable being that converting to a `sparse.coo_matrix` and then acessing row & column indicies is much more memory efficient than converting to a `sparse.dok_matrix`. In fact for a reasonably large matrix the `sparse.dok_matrix` did not fit in memory for me. Aside from that they are equivalent.